### PR TITLE
#4653 | Fix if guard exploding in case patterns with trailing commas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Remove support for pre-python 3.7 `await/async` as soft keywords/variable names
   (#4676)
 - Fix crash on parenthesized expression inside a type parameter bound (#4684)
+- Fix if guard exploding in case patterns with trailing commas (#4653)
 
 ### Preview style
 

--- a/src/black/linegen.py
+++ b/src/black/linegen.py
@@ -1051,16 +1051,6 @@ def _should_keep_parens_in_case_guard(
     return True
 
 
-def _is_case_guard(line: Line) -> bool:
-    found_case = False
-    for leaf in line.leaves:
-        if leaf.value == "case":
-            found_case = True
-        elif found_case and leaf.value == "if":
-            return True
-    return False
-
-
 def _prefer_split_rhs_oop_over_rhs(
     rhs_oop: RHSResult, rhs: RHSResult, mode: Mode
 ) -> bool:

--- a/tests/data/cases/pattern_matching_with_if_stmt_explode.py
+++ b/tests/data/cases/pattern_matching_with_if_stmt_explode.py
@@ -1,0 +1,99 @@
+# flags: --minimum-version=3.10
+
+# case black_test_match_case_conditional_001
+def f(x):
+    match x:
+        # Should change
+        case [
+            y
+        ] if y == 123:
+            pass
+
+        # Should change
+        case [
+            y
+        ] if True:
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if True:
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if y == 123:
+            pass
+
+        # Should change
+        case [
+            y,
+        ] if (
+            y == 123
+        ):
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if c(
+            very_complex=True,
+            perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1,
+        ):
+            pass
+
+        # Should change
+        case [
+            y,
+        ] if perhaps_even_looooooooooooooooooooooooooooooooooooooooooooooooong == True:
+            pass
+
+# output
+
+# case black_test_match_case_conditional_001
+def f(x):
+    match x:
+        # Should change
+        case [y] if y == 123:
+            pass
+
+        # Should change
+        case [y] if True:
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if True:
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if y == 123:
+            pass
+
+        # Should change
+        case [
+            y,
+        ] if y == 123:
+            pass
+
+        # Should not change
+        case [
+            y,
+        ] if c(
+            very_complex=True,
+            perhaps_even_loooooooooooooooooooooooooooooooooooooong=-1,
+        ):
+            pass
+
+        # Should change
+        case [
+            y,
+        ] if (
+            perhaps_even_looooooooooooooooooooooooooooooooooooooooooooooooong == True
+        ):
+            pass


### PR DESCRIPTION
### Description

Fix if guard exploding in case patterns with trailing commas (#4653)
This change is for COMP-354 class Summer 2025

### Checklist - did you ...

- [x ] Add an entry in `CHANGES.md` if necessary?
yes adeded
- [x ] Add / update tests if necessary?
Added a test case for this
- [ ] Add new / update outdated documentation?
